### PR TITLE
Add sitemap, sitemap index, and robots.txt for SEO

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/metrics/",
+    },
+    sitemap: "https://payai.network/sitemap_index.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://payai.network";
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/privacy-policy`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/terms-of-service`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+  ];
+}

--- a/src/app/sitemap_index.xml/route.ts
+++ b/src/app/sitemap_index.xml/route.ts
@@ -1,0 +1,18 @@
+export function GET() {
+  const sitemaps = [
+    "https://payai.network/sitemap.xml",
+    "https://blog.payai.network/sitemap.xml",
+    "https://docs.payai.network/sitemap.xml",
+  ];
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemaps.map((url) => `  <sitemap>\n    <loc>${url}</loc>\n  </sitemap>`).join("\n")}
+</sitemapindex>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
+}


### PR DESCRIPTION
- sitemap.xml lists root domain pages (home, privacy-policy, terms-of-service)
- sitemap_index.xml serves as master index referencing root, blog, and docs sitemaps
- robots.txt allows all crawlers and points to the sitemap index