### PR TITLE
fix: ecosystem auto-PR workflow fails to parse logo from issue uploads

### DIFF
--- a/.github/workflows/add-project.yml
+++ b/.github/workflows/add-project.yml
@@ -48,10 +48,16 @@ jobs:
             const testimonial = getField('Testimonial (optional)');
             const testimonialAuthor = getField('Testimonial Author (optional)');
 
-            // Extract image URL from markdown syntax or plain URL
-            let logoUrl = logoRaw;
-            const imgMatch = logoRaw.match(/!\[.*?\]\((.*?)\)/);
-            if (imgMatch) logoUrl = imgMatch[1];
+            // Extract image URL. GitHub stores uploaded images as <img src="...">
+            // tags (sometimes wrapped in a markdown link); older submissions may use
+            // markdown image syntax or a plain URL. Handle all cases.
+            let logoUrl = '';
+            const imgTag = logoRaw.match(/<img[^>]*\bsrc=["']([^"']+)["']/i);
+            const mdImg = logoRaw.match(/!\[[^\]]*\]\(([^)]+)\)/);
+            const bareUrl = logoRaw.match(/https?:\/\/[^\s)"'<>]+/);
+            if (imgTag) logoUrl = imgTag[1];
+            else if (mdImg) logoUrl = mdImg[1];
+            else if (bareUrl) logoUrl = bareUrl[0];
             logoUrl = logoUrl.trim();
 
             if (!logoUrl) {
@@ -87,7 +93,16 @@ jobs:
             // Download logo
             const logoFilename = `${slug}${ext}`;
             const logoPath = `public/projects/${logoFilename}`;
-            execFileSync('curl', ['-sL', logoUrl, '-o', logoPath]);
+            try {
+              execFileSync('curl', ['-fsL', logoUrl, '-o', logoPath]);
+            } catch (e) {
+              core.setFailed(`Failed to download logo from: ${logoUrl}`);
+              return;
+            }
+            if (!fs.existsSync(logoPath) || fs.statSync(logoPath).size === 0) {
+              core.setFailed(`Downloaded logo is empty from: ${logoUrl}`);
+              return;
+            }
 
             // Update projects.json
             const projectsPath = 'src/data/projects.json';


### PR DESCRIPTION
## Problem

The **Add Project to Ecosystem** workflow stopped auto-creating PRs. The last several runs failed at the first step (`Parse issue and update project data`), so they never reached PR creation — e.g. issue #51 (_done) and the Jun 3 run (obscra) both had to be added by hand.

## Root cause

The script extracted the logo URL only from **markdown image** syntax:

```js
const imgMatch = logoRaw.match(/!\[.*?\]\((.*?)\)/);
```

But GitHub stores issue-form image uploads as **HTML `<img src="...">` tags**, often wrapped in a markdown link:

```
[

<img ... src="https://github.com/user-attachments/assets/...">

](url)
```

That doesn't match the markdown-image regex, so `logoUrl` stayed as the raw multi-line blob and was handed to `curl`, which errored. Because the `curl` call wasn't guarded, it threw an **unhandled exception that killed the whole job** before the "Create pull request" step.

Observed failures:
- Jun 8 (#51): `Error: Command failed: curl -sL [`
- Jun 3 (obscra): `Error: Command failed: curl -sL <img width="2000"...>`

## Fix

- Extract the logo URL from `<img src>`, markdown image syntax, **or** a bare URL — covering every format GitHub produces.
- Wrap the download (`curl -fsL`) in try/catch and verify the file is non-empty, so a bad logo fails with a clear message instead of crashing the job.

Verified the new extraction against the exact bodies of issue #51 and the obscra submission, plus markdown-image and plain-URL inputs — all resolve to the correct URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)