### PR TITLE
ci: trigger ecosystem workflow on labeled events

### DIFF
--- a/.github/workflows/add-project.yml
+++ b/.github/workflows/add-project.yml
@@ -2,7 +2,7 @@ name: Add Project to Ecosystem
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 jobs:
   add-project:


### PR DESCRIPTION
Fixes the ecosystem-submission automation for external contributors.

## Problem

The `Add Project to Ecosystem` workflow only triggers on `issues: [opened]` and gates the job on:

```yaml
if: contains(github.event.issue.labels.*.name, "ecosystem")
```

The issue form template (`.github/ISSUE_TEMPLATE/add-project.yml`) declares `labels: ["ecosystem"]`, so the label *should* be present at open time. But **GitHub silently drops issue-form-declared labels when the submitter lacks write access to the repo** — which is every external project submitter (`author_association: NONE`), i.e. the exact audience this form exists for.

Result: the issue opens with no labels, the gate evaluates false, and the `add-project` job is skipped. This is what happened to [#66 "[Ecosystem] Utilia"](https://github.com/PayAINetwork/payai-website/issues/66) (no labels, no labeling events in its timeline, job skipped in 0s).

Re-running the workflow does not help — it replays the original `opened` payload, which still has no label.

## Fix

Also trigger on the `labeled` event:

```yaml
on:
  issues:
    types: [opened, labeled]
```

The `ecosystem` label gate is unchanged. Now a maintainer adding the `ecosystem` label to a submission fires the workflow. This also adds a natural human review checkpoint before the bot generates a PR from an outside submission.

- Internal submissions that already carry the label at open time keep working via `opened`.
- External submissions get picked up when a maintainer applies the label.

## Backlog note

To process #66 after this merges, a maintainer just needs to add the `ecosystem` label to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)