### PR TITLE
feat: move the blog from blog.payai.network to payai.network/blog

### DIFF
--- a/src/app/api/md/route.ts
+++ b/src/app/api/md/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest } from "next/server";
-import { AUTHORED_PAGES, DERIVED_PAGES, notFoundMarkdown } from "@/lib/agent/pages";
+import {
+  AUTHORED_PAGES,
+  DERIVED_PAGES,
+  isBlogPath,
+  notFoundMarkdown,
+} from "@/lib/agent/pages";
+import { blogMarkdown } from "@/lib/blog";
 import { htmlToMarkdown } from "@/lib/agent/htmlToMarkdown";
 import { SITE_URL } from "@/lib/site";
 
@@ -60,6 +66,26 @@ export async function GET(request: NextRequest) {
   const authored = AUTHORED_PAGES[pathname];
   if (authored) {
     return new Response(authored(), { headers: MARKDOWN_HEADERS });
+  }
+
+  /*
+   * Blog posts come from Ghost, so they are absent from DERIVED_PAGES and are
+   * rendered from the CMS payload rather than by re-reading our own HTML. A
+   * slug Ghost does not know still has to 404 — answering 200 for every
+   * /blog/<anything> would hand crawlers an unbounded set of soft-404s.
+   */
+  if (isBlogPath(pathname)) {
+    const markdown = await blogMarkdown(pathname, SITE_URL);
+    if (markdown) {
+      return new Response(
+        `${markdown}\n\n---\n\nCanonical HTML: ${SITE_URL}${pathname}\n`,
+        { headers: MARKDOWN_HEADERS },
+      );
+    }
+    return new Response(notFoundMarkdown(pathname), {
+      status: 404,
+      headers: MARKDOWN_HEADERS,
+    });
   }
 
   /*

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,265 @@
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight, ChevronRight } from "lucide-react";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { PostCard } from "@/components/blog/PostCard";
+import { NewsletterSignup } from "@/components/blog/NewsletterSignup";
+import {
+  extractInjectedJsonLd,
+  formatPostDate,
+  getPost,
+  getPostSlugs,
+  getRelatedPosts,
+  postExcerpt,
+  postMetaDescription,
+  renderPostHtml,
+  tagUrl,
+} from "@/lib/blog";
+import {
+  buildBlogPostingSchema,
+  buildBreadcrumbSchema,
+} from "@/lib/schema";
+import { SITE_URL } from "@/lib/site";
+
+// Next requires a literal here; keep it in step with BLOG_REVALIDATE.
+export const revalidate = 3600;
+
+type Params = { params: Promise<{ slug: string }> };
+
+export async function generateStaticParams() {
+  const slugs = await getPostSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: Params) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  if (!post) return {};
+
+  const url = `${SITE_URL}/blog/${post.slug}`;
+  const description = postMetaDescription(post) || undefined;
+  const image = post.og_image || post.feature_image || undefined;
+
+  return {
+    title: post.meta_title || post.title,
+    description,
+    alternates: {
+      /*
+       * Ghost's own canonical_url wins when an author set one — that field
+       * exists precisely to point at an original published elsewhere, and
+       * overriding it would claim someone else's content.
+       */
+      canonical: post.canonical_url || url,
+      types: { "text/markdown": `${url}.md` },
+    },
+    openGraph: {
+      type: "article",
+      url,
+      title: post.og_title || post.meta_title || post.title,
+      description: post.og_description || description,
+      publishedTime: post.published_at ?? undefined,
+      modifiedTime: post.updated_at ?? undefined,
+      authors: post.authors?.map((author) => author.name),
+      tags: post.tags?.map((tag) => tag.name),
+      ...(image ? { images: [{ url: image }] } : {}),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.twitter_title || post.title,
+      description: post.twitter_description || description,
+      ...(post.twitter_image || image
+        ? { images: [post.twitter_image || image!] }
+        : {}),
+    },
+  };
+}
+
+export default async function BlogPostPage({ params }: Params) {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  if (!post) notFound();
+
+  const related = await getRelatedPosts(post);
+  const author = post.primary_author ?? post.authors?.[0];
+  const body = renderPostHtml(post.html);
+  const injected = extractInjectedJsonLd(post);
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <JsonLd data={buildBlogPostingSchema(post)} id="ld-post" />
+      <JsonLd
+        data={buildBreadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Blog", path: "/blog" },
+          { name: post.title, path: `/blog/${post.slug}` },
+        ])}
+        id="ld-post-breadcrumb"
+      />
+      {injected.map((node, index) => (
+        <JsonLd key={index} data={node} id={`ld-post-injected-${index}`} />
+      ))}
+
+      <main>
+        <article>
+          <header className="container-payai pt-8 lg:pt-14">
+            <nav aria-label="Breadcrumb">
+              <ol className="flex items-center gap-1.5 text-sm text-[#71717A]">
+                <li>
+                  <Link href="/" className="hover:text-[#1D45D8]">
+                    Home
+                  </Link>
+                </li>
+                <ChevronRight aria-hidden className="h-3.5 w-3.5" />
+                <li>
+                  <Link href="/blog" className="hover:text-[#1D45D8]">
+                    Blog
+                  </Link>
+                </li>
+              </ol>
+            </nav>
+
+            <div className="mx-auto max-w-[48rem] pt-8 lg:pt-12">
+              {post.primary_tag && (
+                <Link
+                  href={tagUrl(post.primary_tag.slug)}
+                  className="text-sm lg:text-base font-medium text-[#1D45D8] hover:underline"
+                >
+                  {post.primary_tag.name}
+                </Link>
+              )}
+              <h1 className="mt-3 text-3xl lg:text-[44px] lg:leading-[56px] font-medium text-[#09090B]">
+                {post.title}
+              </h1>
+              {postExcerpt(post) && (
+                <p className="mt-4 lg:mt-6 text-base lg:text-xl text-[#0A0A0A]/60">
+                  {postExcerpt(post)}
+                </p>
+              )}
+
+              <div className="mt-6 lg:mt-8 flex flex-wrap items-center gap-3 text-sm text-[#0A0A0A]/60">
+                {author?.profile_image && (
+                  <Image
+                    src={author.profile_image}
+                    alt={author.name}
+                    width={32}
+                    height={32}
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                )}
+                {author?.name && (
+                  <span className="text-[#09090B]">{author.name}</span>
+                )}
+                {post.published_at && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <time dateTime={post.published_at}>
+                      {formatPostDate(post.published_at)}
+                    </time>
+                  </>
+                )}
+                {post.reading_time && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span>{post.reading_time} min read</span>
+                  </>
+                )}
+              </div>
+            </div>
+          </header>
+
+          {post.feature_image && (
+            <figure className="container-payai mt-8 lg:mt-12">
+              <div className="relative mx-auto aspect-[16/9] w-full max-w-[56rem] overflow-hidden rounded-xl border border-[#EDEDED]">
+                <Image
+                  src={post.feature_image}
+                  alt={post.feature_image_alt || post.title}
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 896px"
+                  className="object-cover"
+                  priority
+                />
+              </div>
+              {post.feature_image_caption && (
+                <figcaption
+                  className="mx-auto mt-3 max-w-[56rem] text-center text-sm text-[#71717A]"
+                  // Ghost stores captions as HTML so links inside them survive.
+                  dangerouslySetInnerHTML={{ __html: post.feature_image_caption }}
+                />
+              )}
+            </figure>
+          )}
+
+          <div className="container-payai py-10 lg:py-16">
+            <div
+              className="blog-prose mx-auto max-w-[48rem]"
+              dangerouslySetInnerHTML={{ __html: body }}
+            />
+
+            {post.tags && post.tags.length > 0 && (
+              <div className="mx-auto mt-12 max-w-[48rem] border-t border-[#EDEDED] pt-8">
+                <h2 className="text-sm font-medium text-[#71717A]">Topics</h2>
+                <ul className="mt-3 flex flex-wrap gap-2">
+                  {post.tags.map((tag) => (
+                    <li key={tag.id}>
+                      <Link
+                        href={tagUrl(tag.slug)}
+                        className="inline-block rounded-full border border-[#E4E4E7] px-3 py-1.5 text-sm text-[#09090B] transition-colors hover:border-[#1D45D8] hover:text-[#1D45D8]"
+                      >
+                        {tag.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/*
+              An internal link into the product from every post. These pages are
+              where the inbound links land; the whole point of moving the blog
+              onto this domain is that they can now pass weight to /developers.
+            */}
+            <aside className="mx-auto mt-10 max-w-[48rem] rounded-xl border border-[#EDEDED] bg-[#F8F9FF] px-6 py-8">
+              <h2 className="text-xl lg:text-2xl font-medium text-[#09090B]">
+                Start accepting agentic payments
+              </h2>
+              <p className="mt-2 text-sm lg:text-base text-[#71717A]">
+                One integration for x402 across Solana, Base, Polygon, Arbitrum,
+                Avalanche, and Sei. No API keys, no accounts, instant settlement.
+              </p>
+              <Link
+                href="/developers"
+                className="mt-5 inline-flex items-center justify-center rounded-lg bg-[linear-gradient(90deg,#4D63F6_17%,#1D45D8_65%)] px-4 py-2.5 text-sm font-medium text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.2)]"
+              >
+                Read the developer guide
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </aside>
+          </div>
+        </article>
+
+        {related.length > 0 && (
+          <section className="border-t border-[#EDEDED] py-12 lg:py-20">
+            <div className="container-payai">
+              <h2 className="text-2xl lg:text-[32px] font-medium text-[#09090B]">
+                Keep reading
+              </h2>
+              <div className="mt-8 grid grid-cols-1 lg:grid-cols-3 bg-white">
+                {related.map((item) => (
+                  <PostCard key={item.id} post={item} />
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        <NewsletterSignup />
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { PostCard } from "@/components/blog/PostCard";
+import { NewsletterSignup } from "@/components/blog/NewsletterSignup";
+import { getPosts, getTagsWithCounts, tagUrl } from "@/lib/blog";
+import { buildBlogSchema, buildBreadcrumbSchema } from "@/lib/schema";
+import { SITE_URL } from "@/lib/site";
+
+// Next requires a literal here; keep it in step with BLOG_REVALIDATE.
+export const revalidate = 3600;
+
+const DESCRIPTION =
+  "Insights and updates from the x402 ecosystem and PayAI Network — agentic payments, facilitator engineering, and the machine economy.";
+
+export const metadata = {
+  title: "Blog",
+  description: DESCRIPTION,
+  alternates: {
+    canonical: `${SITE_URL}/blog`,
+    types: {
+      "application/rss+xml": `${SITE_URL}/blog/rss.xml`,
+      "text/markdown": `${SITE_URL}/blog.md`,
+    },
+  },
+  openGraph: {
+    type: "website",
+    title: "PayAI Blog",
+    description: DESCRIPTION,
+    url: `${SITE_URL}/blog`,
+  },
+};
+
+export default async function BlogIndexPage() {
+  const [posts, tags] = await Promise.all([getPosts(), getTagsWithCounts()]);
+
+  // Ghost's own `featured` flag decides the hero; newest wins when none is set.
+  const featured = posts.find((post) => post.featured) ?? posts[0];
+  const rest = posts.filter((post) => post.id !== featured?.id);
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <JsonLd data={buildBlogSchema(posts)} id="ld-blog" />
+      <JsonLd
+        data={buildBreadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Blog", path: "/blog" },
+        ])}
+        id="ld-blog-breadcrumb"
+      />
+
+      <main>
+        <header className="container-payai pt-12 lg:pt-20 pb-8 lg:pb-12">
+          <div className="max-w-[48rem]">
+            <h1 className="text-3xl lg:text-[48px] lg:leading-[60px] font-medium text-[#09090B]">
+              Blog
+            </h1>
+            <p className="text-base lg:text-lg text-[#0A0A0A]/60 mt-4">
+              {DESCRIPTION}
+            </p>
+          </div>
+
+          {tags.length > 0 && (
+            <nav aria-label="Browse by topic" className="mt-8 flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <Link
+                  key={tag.id}
+                  href={tagUrl(tag.slug)}
+                  className="rounded-full border border-[#E4E4E7] px-3 py-1.5 text-sm text-[#09090B] transition-colors hover:border-[#1D45D8] hover:text-[#1D45D8]"
+                >
+                  {tag.name}
+                </Link>
+              ))}
+            </nav>
+          )}
+        </header>
+
+        {posts.length === 0 ? (
+          <p className="container-payai py-20 text-center text-[#71717A]">
+            No posts found.
+          </p>
+        ) : (
+          <div className="space-y-6 lg:space-y-[60px] pb-12 lg:pb-20">
+            {featured && (
+              <div className="container-payai">
+                <PostCard post={featured} featured headingLevel="h2" />
+              </div>
+            )}
+
+            {rest.length > 0 && (
+              <div className="container-payai">
+                <h2 className="sr-only">All posts</h2>
+                <div className="grid grid-cols-1 lg:grid-cols-3 bg-white">
+                  {rest.map((post) => (
+                    <PostCard key={post.id} post={post} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <NewsletterSignup />
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/blog/rss.xml/route.ts
+++ b/src/app/blog/rss.xml/route.ts
@@ -1,0 +1,75 @@
+import {
+  getPostsWithContent,
+  postTeaser,
+  rewriteGhostHtml,
+} from "@/lib/blog";
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * RSS feed for the blog.
+ *
+ * Replaces the Ghost-generated feed that used to live at
+ * blog.payai.network/rss/. Existing subscribers are redirected here at the
+ * edge, so this has to keep working for as long as that redirect does.
+ */
+// Next requires a literal here; keep it in step with BLOG_REVALIDATE.
+export const revalidate = 3600;
+
+const FEED_URL = `${SITE_URL}/blog/rss.xml`;
+
+/** CDATA is not nestable — the only sequence that can break out is "]]>". */
+function cdata(value: string): string {
+  return `<![CDATA[${value.replace(/]]>/g, "]]]]><![CDATA[>")}]]>`;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export async function GET() {
+  const posts = await getPostsWithContent();
+  const updated = posts[0]?.published_at ?? new Date().toISOString();
+
+  const items = posts
+    .map((post) => {
+      const url = `${SITE_URL}/blog/${post.slug}`;
+      const author = post.primary_author ?? post.authors?.[0];
+
+      return `    <item>
+      <title>${cdata(post.title)}</title>
+      <link>${escapeXml(url)}</link>
+      <guid isPermaLink="true">${escapeXml(url)}</guid>
+      <pubDate>${new Date(post.published_at ?? Date.now()).toUTCString()}</pubDate>
+${author ? `      <dc:creator>${cdata(author.name)}</dc:creator>\n` : ""}${(post.tags ?? [])
+        .map((tag) => `      <category>${cdata(tag.name)}</category>`)
+        .join("\n")}
+      <description>${cdata(postTeaser(post))}</description>
+      <content:encoded>${cdata(rewriteGhostHtml(post.html))}</content:encoded>
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>PayAI Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Insights and updates from the x402 ecosystem and PayAI Network.</description>
+    <language>en</language>
+    <lastBuildDate>${new Date(updated).toUTCString()}</lastBuildDate>
+    <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/blog/tag/[slug]/page.tsx
+++ b/src/app/blog/tag/[slug]/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { PostCard } from "@/components/blog/PostCard";
+import { NewsletterSignup } from "@/components/blog/NewsletterSignup";
+import {
+  TAG_INDEX_MIN_POSTS,
+  getPostsByTag,
+  getTag,
+  getTagsWithCounts,
+} from "@/lib/blog";
+import { buildBreadcrumbSchema, buildTagPageSchema } from "@/lib/schema";
+import { SITE_URL } from "@/lib/site";
+
+// Next requires a literal here; keep it in step with BLOG_REVALIDATE.
+export const revalidate = 3600;
+
+type Params = { params: Promise<{ slug: string }> };
+
+export async function generateStaticParams() {
+  const tags = await getTagsWithCounts();
+  return tags.map((tag) => ({ slug: tag.slug }));
+}
+
+export async function generateMetadata({ params }: Params) {
+  const { slug } = await params;
+  const [tag, posts] = await Promise.all([getTag(slug), getPostsByTag(slug)]);
+  if (!tag) return {};
+
+  const description =
+    tag.description ||
+    `Posts about ${tag.name} from the PayAI Network team — x402, agentic payments, and the machine economy.`;
+
+  return {
+    title: `${tag.name} — Blog`,
+    description,
+    alternates: { canonical: `${SITE_URL}/blog/tag/${tag.slug}` },
+    // Thin archives stay out of the index; see TAG_INDEX_MIN_POSTS.
+    ...(posts.length < TAG_INDEX_MIN_POSTS
+      ? { robots: { index: false, follow: true } }
+      : {}),
+    openGraph: {
+      type: "website",
+      title: `${tag.name} — PayAI Blog`,
+      description,
+      url: `${SITE_URL}/blog/tag/${tag.slug}`,
+    },
+  };
+}
+
+export default async function BlogTagPage({ params }: Params) {
+  const { slug } = await params;
+  const [tag, posts] = await Promise.all([getTag(slug), getPostsByTag(slug)]);
+  if (!tag || posts.length === 0) notFound();
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <JsonLd data={buildTagPageSchema(tag, posts)} id="ld-tag" />
+      <JsonLd
+        data={buildBreadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Blog", path: "/blog" },
+          { name: tag.name, path: `/blog/tag/${tag.slug}` },
+        ])}
+        id="ld-tag-breadcrumb"
+      />
+
+      <main>
+        <header className="container-payai pt-8 lg:pt-14 pb-8 lg:pb-12">
+          <nav aria-label="Breadcrumb">
+            <ol className="flex items-center gap-1.5 text-sm text-[#71717A]">
+              <li>
+                <Link href="/" className="hover:text-[#1D45D8]">
+                  Home
+                </Link>
+              </li>
+              <ChevronRight aria-hidden className="h-3.5 w-3.5" />
+              <li>
+                <Link href="/blog" className="hover:text-[#1D45D8]">
+                  Blog
+                </Link>
+              </li>
+            </ol>
+          </nav>
+
+          <div className="max-w-[48rem] pt-8 lg:pt-12">
+            <h1 className="text-3xl lg:text-[48px] lg:leading-[60px] font-medium text-[#09090B]">
+              {tag.name}
+            </h1>
+            <p className="mt-4 text-base lg:text-lg text-[#0A0A0A]/60">
+              {tag.description ||
+                `${posts.length} ${posts.length === 1 ? "post" : "posts"} from the PayAI Network team.`}
+            </p>
+          </div>
+        </header>
+
+        <div className="container-payai pb-12 lg:pb-20">
+          <div className="grid grid-cols-1 lg:grid-cols-3 bg-white">
+            {posts.map((post) => (
+              <PostCard key={post.id} post={post} headingLevel="h2" />
+            ))}
+          </div>
+        </div>
+
+        <NewsletterSignup />
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -273,3 +273,166 @@ pre {
     @apply bg-background text-foreground;
   }
 }
+
+/*
+ * Typography for post bodies rendered from the Ghost Content API.
+ *
+ * Ghost returns finished HTML, so this styles that markup rather than being
+ * applied by the components. Scoped to .blog-prose so it can never leak into
+ * the marketing pages.
+ *
+ * The Koenig card classes below (kg-*) are the ones the current 21 posts
+ * actually use — image, callout, and CTA cards. If a post starts using a card
+ * type that is not styled here it will render unstyled but readable; add it
+ * rather than pulling in Ghost's own stylesheet, which would put a
+ * render-blocking third-party request on the site's most linked pages.
+ */
+.blog-prose {
+  @apply text-[17px] leading-[1.75] text-[#27272A];
+}
+
+.blog-prose > * + * {
+  @apply mt-6;
+}
+
+.blog-prose h2 {
+  @apply mt-12 text-2xl lg:text-[32px] lg:leading-[44px] font-medium text-[#09090B] scroll-mt-24;
+}
+
+.blog-prose h3 {
+  @apply mt-10 text-xl lg:text-2xl font-medium text-[#09090B] scroll-mt-24;
+}
+
+.blog-prose h4 {
+  @apply mt-8 text-lg font-medium text-[#09090B] scroll-mt-24;
+}
+
+.blog-prose a {
+  @apply text-[#1D45D8] underline underline-offset-2 hover:opacity-70;
+}
+
+.blog-prose strong {
+  @apply font-semibold text-[#09090B];
+}
+
+.blog-prose ul {
+  @apply list-disc pl-6;
+}
+
+.blog-prose ol {
+  @apply list-decimal pl-6;
+}
+
+.blog-prose li + li {
+  @apply mt-2;
+}
+
+.blog-prose li > ul,
+.blog-prose li > ol {
+  @apply mt-2;
+}
+
+.blog-prose blockquote {
+  @apply border-l-4 border-[#4D63F6] pl-5 italic text-[#3F3F46];
+}
+
+.blog-prose code {
+  @apply rounded bg-[#F4F4F5] px-1.5 py-0.5 font-mono text-[0.875em] text-[#09090B];
+}
+
+.blog-prose pre {
+  @apply overflow-x-auto rounded-xl bg-[#0A192F] p-5 text-sm leading-relaxed text-[#E4E4E7];
+}
+
+.blog-prose pre code {
+  @apply bg-transparent p-0 text-inherit;
+}
+
+.blog-prose hr {
+  @apply my-10 border-t border-[#E4E4E7];
+}
+
+.blog-prose img {
+  @apply h-auto w-full rounded-lg;
+}
+
+.blog-prose figcaption {
+  @apply mt-3 text-center text-sm text-[#71717A];
+}
+
+/* Wide tables are the one element most likely to overflow on mobile. */
+.blog-prose .table-wrapper {
+  @apply overflow-x-auto;
+}
+
+.blog-prose table {
+  @apply w-full border-collapse text-left text-[15px];
+}
+
+.blog-prose th,
+.blog-prose td {
+  @apply border border-[#E4E4E7] px-4 py-2.5 align-top;
+}
+
+.blog-prose th {
+  @apply bg-[#FAFAFA] font-medium text-[#09090B];
+}
+
+/* --- Koenig cards ------------------------------------------------------- */
+
+.blog-prose .kg-card {
+  @apply my-8;
+}
+
+/*
+ * Ghost's width variants break out of the measure. The negative margins are
+ * capped by the viewport at small sizes so a full-width card cannot introduce
+ * horizontal page scroll.
+ */
+.blog-prose .kg-width-wide {
+  @apply lg:-mx-16;
+}
+
+.blog-prose .kg-width-full {
+  @apply lg:-mx-24;
+}
+
+.blog-prose .kg-image-card img {
+  @apply mx-auto rounded-lg border border-[#EDEDED];
+}
+
+.blog-prose .kg-callout-card {
+  @apply flex gap-4 rounded-xl border border-[#E4E4E7] bg-[#FAFAFA] px-5 py-4;
+}
+
+.blog-prose .kg-callout-card-blue {
+  @apply border-[#C4CDFB] bg-[#F0F2FE];
+}
+
+.blog-prose .kg-callout-emoji {
+  @apply shrink-0 text-xl leading-[1.6];
+}
+
+.blog-prose .kg-callout-text {
+  @apply text-[15px] leading-[1.7] text-[#27272A];
+}
+
+.blog-prose .kg-cta-card {
+  @apply rounded-xl border border-[#E4E4E7] px-6 py-6;
+}
+
+.blog-prose .kg-cta-bg-blue {
+  @apply border-[#C4CDFB] bg-[#F0F2FE];
+}
+
+.blog-prose .kg-cta-minimal {
+  @apply border-0 bg-transparent px-0;
+}
+
+.blog-prose .kg-cta-text {
+  @apply text-[15px] leading-[1.7];
+}
+
+.blog-prose .kg-cta-button {
+  @apply mt-4 inline-flex items-center justify-center rounded-lg bg-[#1D45D8] px-4 py-2.5 text-sm font-medium text-white no-underline hover:opacity-90;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,20 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/site";
+import {
+  TAG_INDEX_MIN_POSTS,
+  getPosts,
+  getTagsWithCounts,
+  type GhostPost,
+} from "@/lib/blog";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+/**
+ * The site's own pages, excluding anything fetched from Ghost.
+ *
+ * Exported synchronously because `DERIVED_PAGES` in src/lib/agent/pages.ts
+ * builds the Markdown allowlist from it, and that list is read by middleware,
+ * which cannot await. Blog paths are matched there by prefix instead.
+ */
+export function staticSitemapEntries(): MetadataRoute.Sitemap {
   const lastModified = new Date();
 
   return [
@@ -42,5 +55,54 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.3,
     },
+  ];
+}
+
+function postEntry(post: GhostPost): MetadataRoute.Sitemap[number] {
+  return {
+    url: `${SITE_URL}/blog/${post.slug}`,
+    /*
+     * Ghost's own updated_at, not the build time. A sitemap that claims every
+     * post changed on every deploy teaches crawlers to ignore the field.
+     */
+    lastModified: new Date(post.updated_at || post.published_at || Date.now()),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  };
+}
+
+/**
+ * Includes every blog post, which is the point of moving the blog onto this
+ * domain: one sitemap, one property, one crawl budget.
+ *
+ * A Ghost outage must not silently ship a sitemap that drops all 21 posts —
+ * that reads to a crawler as mass deletion — so failure throws and fails the
+ * build instead.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [posts, tags] = await Promise.all([getPosts(), getTagsWithCounts()]);
+
+  const blogIndex: MetadataRoute.Sitemap[number] = {
+    url: `${SITE_URL}/blog`,
+    lastModified: new Date(posts[0]?.published_at || Date.now()),
+    changeFrequency: "weekly",
+    priority: 0.9,
+  };
+
+  // Thin tag archives carry noindex, so listing them here would contradict it.
+  const tagEntries = tags
+    .filter((tag) => tag.count.posts >= TAG_INDEX_MIN_POSTS)
+    .map((tag) => ({
+      url: `${SITE_URL}/blog/tag/${tag.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.5,
+    }));
+
+  return [
+    ...staticSitemapEntries(),
+    blogIndex,
+    ...posts.map(postEntry),
+    ...tagEntries,
   ];
 }

--- a/src/app/sitemap_index.xml/route.ts
+++ b/src/app/sitemap_index.xml/route.ts
@@ -1,7 +1,9 @@
 /**
- * Aggregates sitemaps from all PayAI subdomains so Google can crawl one entry
- * point and discover content across marketing, blog, and docs. Helps mitigate
- * the SEO equity fragmentation that comes with hosting on separate subdomains.
+ * Aggregates sitemaps across PayAI hosts so Google can crawl one entry point.
+ *
+ * The blog is no longer listed here: it moved from blog.payai.network into
+ * /blog on this domain, so its posts are in this site's own sitemap.xml. Docs
+ * remain on their own subdomain and still need aggregating.
  *
  * If you add a new subdomain (e.g. status.payai.network), add its sitemap here
  * and verify the URL responds with valid XML before deploying.
@@ -9,7 +11,6 @@
 export function GET() {
   const sitemaps = [
     "https://payai.network/sitemap.xml",
-    "https://blog.payai.network/sitemap.xml",
     "https://docs.payai.network/sitemap.xml",
   ];
 

--- a/src/components/blog/NewsletterSignup.tsx
+++ b/src/components/blog/NewsletterSignup.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Ghost's official embeddable signup form, pointed at the Ghost site.
+ *
+ * Ghost(Pro) does not expose Portal at /public/portal.min.js, so this uses the
+ * supported cross-domain embed instead. Signups land in the same members list
+ * the blog has always used, so the migration off the subdomain does not touch
+ * the newsletter.
+ *
+ * Injected imperatively rather than as JSX or next/script for two reasons: the
+ * bundle throws if `document.currentScript` is null, which rules out
+ * next/script's dynamic injection, and a server-rendered <script> tag would not
+ * execute at all on a client-side navigation into the blog.
+ */
+
+const SIGNUP_FORM_SRC =
+  "https://cdn.jsdelivr.net/ghost/signup-form@~0.2/umd/signup-form.min.js";
+
+const GHOST_SITE = (
+  process.env.NEXT_PUBLIC_GHOST_URL || "https://payai.ghost.io"
+).replace(/\/+$/, "");
+
+export function NewsletterSignup({
+  title = "Stay ahead of agentic payments",
+  description = "New posts on x402, agent payments, and the machine economy — straight to your inbox.",
+}: {
+  title?: string;
+  description?: string;
+}) {
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = container.current;
+    // Strict Mode runs effects twice in development; only ever mount one form.
+    if (!host || host.querySelector("script")) return;
+
+    const script = document.createElement("script");
+    script.src = SIGNUP_FORM_SRC;
+    script.async = true;
+    script.dataset.site = GHOST_SITE;
+    script.dataset.locale = "en";
+    script.dataset.title = title;
+    script.dataset.description = description;
+    script.dataset.backgroundColor = "#FFFFFF";
+    script.dataset.textColor = "#09090B";
+    script.dataset.buttonColor = "#1D45D8";
+    script.dataset.buttonTextColor = "#FFFFFF";
+
+    host.appendChild(script);
+
+    return () => {
+      host.replaceChildren();
+    };
+  }, [title, description]);
+
+  return (
+    <section
+      aria-label="Newsletter signup"
+      className="border-y border-[#EDEDED] bg-[#F8F9FF]"
+    >
+      <div className="container-payai py-10 lg:py-16">
+        {/*
+          Reserves the form's height so the surrounding layout does not shift
+          when the embed mounts — a visible bounce on the site's most-linked
+          pages would be a self-inflicted Core Web Vitals problem.
+        */}
+        <div ref={container} className="mx-auto max-w-[42rem] min-h-[220px]" />
+      </div>
+    </section>
+  );
+}

--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -1,0 +1,123 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { GhostPost } from "@/lib/blog";
+import { formatPostDate, postTeaser, postUrl } from "@/lib/blog";
+
+/**
+ * Post teaser used by the blog index, tag archives, and the related-posts
+ * strip. `featured` renders the wide two-column treatment; the default is the
+ * grid cell.
+ *
+ * Deliberately a plain <Link> to a path on this site — these used to point at
+ * blog.payai.network with target="_blank", which made every one of them an
+ * external link out of the domain they were meant to strengthen.
+ */
+export function PostCard({
+  post,
+  featured = false,
+  headingLevel: Heading = "h3",
+}: {
+  post: GhostPost;
+  featured?: boolean;
+  headingLevel?: "h2" | "h3";
+}) {
+  const excerpt = postTeaser(post);
+  const tag = post.primary_tag;
+
+  if (featured) {
+    return (
+      <Link
+        href={postUrl(post.slug)}
+        className="group grid grid-rows-2 lg:grid-rows-1 lg:grid-cols-2 bg-white lg:h-[520px] w-full border border-[#EDEDED] transition-all duration-200 hover:bg-[#F8F9FF] hover:-translate-y-0.5 hover:shadow-md"
+      >
+        <div className="px-4 lg:px-8 py-6 lg:py-10 w-full flex flex-col justify-between gap-8">
+          <div>
+            {tag && (
+              <span className="text-sm lg:text-base text-[#1D45D8] font-medium">
+                {tag.name}
+              </span>
+            )}
+            <Heading className="text-2xl lg:text-[32px] lg:leading-[46px] font-medium text-[#09090B] mt-2 lg:mt-3 transition-colors duration-200 group-hover:text-[#1D45D8]">
+              {post.title}
+            </Heading>
+            {excerpt && (
+              <p className="text-sm lg:text-base text-[#71717A] mt-3 lg:mt-6 line-clamp-4">
+                {excerpt}
+              </p>
+            )}
+          </div>
+          <PostByline post={post} />
+        </div>
+        <div className="p-4 border-t lg:border-t-0 lg:border-l border-[#E4E4E7]">
+          <div className="relative w-full h-full min-h-[200px] overflow-hidden">
+            {post.feature_image && (
+              <Image
+                src={post.feature_image}
+                alt={post.feature_image_alt || post.title}
+                fill
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+                priority
+              />
+            )}
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href={postUrl(post.slug)}
+      className="group px-4 lg:px-8 py-6 lg:py-10 w-full flex flex-col justify-between border border-[#EDEDED] gap-8 transition-all duration-200 hover:bg-[#F8F9FF] hover:-translate-y-0.5 hover:shadow-md"
+    >
+      <div>
+        {tag && (
+          <span className="text-[#1D45D8] font-medium text-sm">{tag.name}</span>
+        )}
+        <Heading className="text-xl lg:text-[28px] lg:leading-[40px] font-medium text-[#09090B] mt-2 lg:mt-3 line-clamp-3 transition-colors duration-200 group-hover:text-[#1D45D8]">
+          {post.title}
+        </Heading>
+        {excerpt && (
+          <p className="text-sm lg:text-base text-[#71717A] mt-3 lg:mt-6 line-clamp-3">
+            {excerpt}
+          </p>
+        )}
+      </div>
+      <PostByline post={post} />
+    </Link>
+  );
+}
+
+function PostByline({ post }: { post: GhostPost }) {
+  const author = post.primary_author ?? post.authors?.[0];
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-2 min-w-0">
+        {author?.profile_image && (
+          <Image
+            src={author.profile_image}
+            alt={author.name}
+            width={26}
+            height={26}
+            className="w-6 h-6 rounded-full object-cover shrink-0"
+          />
+        )}
+        {author?.name && (
+          <span className="text-[13px] lg:text-sm text-[#0A0A0A]/60 truncate">
+            {author.name}
+          </span>
+        )}
+      </div>
+      {post.published_at && (
+        <time
+          dateTime={post.published_at}
+          className="text-[13px] lg:text-sm text-[#0A0A0A]/60 shrink-0"
+        >
+          {formatPostDate(post.published_at)}
+        </time>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -36,13 +36,7 @@ export function Footer() {
                 />
 
                 <Link
-                  href={
-                    process.env.NEXT_PUBLIC_SUBSCRIBE_URL ||
-                    process.env.NEXT_PUBLIC_BLOG_PAYAI_NETWORK ||
-                    "https://blog.payai.network"
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href={process.env.NEXT_PUBLIC_SUBSCRIBE_URL || "/blog"}
                   className="absolute right-1 top-1 bottom-1 inline-flex items-center justify-center
       bg-[linear-gradient(90deg,#4D63F6_17%,#1D45D8_65%)]
       text-white px-4 py-2.5 text-sm font-medium rounded-lg
@@ -72,7 +66,7 @@ export function Footer() {
               <h4 className="text-sm text-[#71717A]">SUPPORT</h4>
               <ul className="space-y-3 text-sm text-[#09090B] mt-6">
                 <li>
-                  <a href={process.env.NEXT_PUBLIC_BLOG_PAYAI_NETWORK} target="_blank" rel="noopener noreferrer">Blog</a>
+                  <Link href="/blog">Blog</Link>
                 </li>
                 <li>
                   <a href={process.env.NEXT_PUBLIC_DISCORD_URL} target="_blank" rel="noopener noreferrer">Discord</a>

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -257,8 +257,7 @@ export function Navbar({ activePage = "home" }) {
                 className="h-full"
               >
                 <Link
-                  href={process.env.NEXT_PUBLIC_BLOG_PAYAI_NETWORK || "#"}
-                  target="_blank"
+                  href="/blog"
                   className="relative h-full flex items-center px-4 text-sm font-medium text-[#0A0A0A] hover:bg-blue-50 hover:border-b-2 hover:border-[#4D63F6]"
                 >
                   <span className="relative z-10">Blog</span>
@@ -482,8 +481,7 @@ export function Navbar({ activePage = "home" }) {
                 className="h-full"
               >
                 <Link
-                  href={process.env.NEXT_PUBLIC_BLOG_PAYAI_NETWORK || "#"}
-                  target="_blank"
+                  href="/blog"
                   className="block py-2 px-3 rounded-lg text-body font-normal transition-all duration-300 text-gray-900 hover:text-gray-600 hover:bg-gray-50"
                 >
                   Blog

--- a/src/components/sections/Blog.jsx
+++ b/src/components/sections/Blog.jsx
@@ -1,59 +1,29 @@
-import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { ghost } from "@/lib/ghost";
+import { PostCard } from "@/components/blog/PostCard";
+import { getPosts, getPostsByTag, tagUrl } from "@/lib/blog";
 
-const blogBase = (process.env.NEXT_PUBLIC_BLOG_PAYAI_NETWORK || "").replace(
-  /\/+$/,
-  "",
-);
-
+/**
+ * Blog teasers for the homepage and, in the case-studies variant, /ecosystem.
+ *
+ * Posts now live at /blog on this domain, so every link here is internal.
+ * They used to point at blog.payai.network with target="_blank", which meant
+ * the homepage spent its outbound link weight on a different host.
+ *
+ * Ghost failures degrade to an empty section rather than throwing: a CMS
+ * outage must not take down the homepage. The /blog routes make the opposite
+ * choice deliberately — there, an empty page would be the bug.
+ */
 export const Blog = async ({ variant = "all" }) => {
   const isCaseStudies = variant === "case-studies";
+
   let posts = [];
-
-  if (isCaseStudies) {
-    try {
-      posts = await ghost.posts.browse({
-        limit: "all",
-        include: ["authors", "tags"],
-        filter: "tag:case-studies",
-        order: "published_at desc"
-      });
-    } catch (error) {
-      console.error('Ghost API filter failed, trying fallback:', error);
-    }
-
-    if (posts.length === 0) {
-      try {
-        const allPosts = await ghost.posts.browse({
-          limit: "all",
-          include: ["authors", "tags"],
-          order: "published_at desc"
-        });
-
-        posts = allPosts.filter(post =>
-          post.tags?.some(tag =>
-            tag.slug === "case-studies" ||
-            tag.name.toLowerCase() === "case studies"
-          )
-        );
-      } catch (fallbackError) {
-        console.error('Ghost API fallback also failed:', fallbackError);
-        posts = [];
-      }
-    }
-  } else {
-    try {
-      posts = await ghost.posts.browse({
-        limit: 4,
-        include: ["authors", "tags"],
-        order: "published_at desc"
-      });
-    } catch (error) {
-      console.error('Ghost API fetch failed:', error);
-      posts = [];
-    }
+  try {
+    posts = isCaseStudies
+      ? await getPostsByTag("case-studies")
+      : await getPosts(4);
+  } catch (error) {
+    console.error("Ghost fetch failed, rendering the blog section empty:", error);
   }
 
   const [featured, ...others] = posts;
@@ -81,59 +51,9 @@ export const Blog = async ({ variant = "all" }) => {
         <div className="space-y-6 lg:space-y-[60px] w-full">
           {featured && (
             <div className="border-y border-[#EDEDED]">
-              <Link
-                href={`${blogBase}/${featured.slug}`}
-                target="_blank"
-                className="container-payai group grid grid-rows-2 lg:grid-rows-1 lg:grid-cols-2 bg-white lg:h-[520px] w-full cursor-pointer transition-all duration-200 hover:bg-[#F8F9FF] hover:-translate-y-0.5 hover:shadow-md"
-              >
-                <div className="border border-[#EDEDED] px-4 lg:px-8 py-6 lg:py-10 w-full flex flex-col justify-between gap-8">
-                  <div>
-                    <span className="text-sm lg:text-base text-[#1D45D8] font-medium">
-                      {featured.tags?.[0]?.name}
-                    </span>
-                    <h3 className="text-2xl lg:text-[32px] lg:leading-[46px] font-medium text-[#09090B] mt-2 lg:mt-3 transition-colors duration-200 group-hover:text-[#1D45D8]">
-                      {featured.title}
-                    </h3>
-                    <p className="text-sm lg:text-base text-[#71717A] mt-3 lg:mt-6">
-                      {featured.excerpt}
-                    </p>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      {featured.authors?.[0]?.profile_image && (
-                        <Image
-                          src={featured.authors[0].profile_image}
-                          alt={featured.authors[0].name}
-                          width={26}
-                          height={26}
-                          className="w-6 h-6 rounded-full object-cover"
-                        />
-                      )}
-                      <p className="text-[13px] lg:text-sm text-[#0A0A0A]/60">
-                        {featured.authors?.[0]?.name}
-                      </p>
-                    </div>
-                    <p className="text-[13px] lg:text-sm text-[#0A0A0A]/60">
-                      {featured.published_at
-                        ? new Date(featured.published_at).toLocaleDateString()
-                        : ""}
-                    </p>
-                  </div>
-                </div>
-                <div className="p-4 border lg:border-l border-[#E4E4E7]">
-                  <div className="relative w-full h-full overflow-hidden">
-                    {featured.feature_image && (
-                      <Image
-                        src={featured.feature_image}
-                        alt={featured.title}
-                        fill
-                        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                        className="object-cover transition-transform duration-300 group-hover:scale-105"
-                      />
-                    )}
-                  </div>
-                </div>
-              </Link>
+              <div className="container-payai">
+                <PostCard post={featured} featured />
+              </div>
             </div>
           )}
 
@@ -141,34 +61,7 @@ export const Blog = async ({ variant = "all" }) => {
             <div className="border-y border-[#E4E4E7]">
               <div className="container-payai grid grid-cols-1 lg:grid-cols-3 border-x border-[#E4E4E7] bg-white w-full">
                 {others.map((post) => (
-                  <Link
-                    key={post.id}
-                    href={`${blogBase}/${post.slug}`}
-                    target="_blank"
-                    className="group px-4 lg:px-8 py-6 lg:py-10 w-full flex flex-col justify-between border border-[#EDEDED] gap-8 cursor-pointer transition-all duration-200 hover:bg-[#F8F9FF] hover:-translate-y-0.5 hover:shadow-md"
-                  >
-                    <div>
-                      <span className="text-[#1D45D8] font-medium">
-                        {post.tags?.[0]?.name}
-                      </span>
-                      <h4 className="text-2xl lg:text-[28px] lg:leading-[40px] font-medium text-[#09090B] mt-2 lg:mt-3 line-clamp-2 transition-colors duration-200 group-hover:text-[#1D45D8]">
-                        {post.title}
-                      </h4>
-                      <p className="text-sm lg:text-base text-[#71717A] mt-3 lg:mt-6 line-clamp-3">
-                        {post.excerpt}
-                      </p>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <p className="text-[13px] lg:text-sm text-[#0A0A0A]/60">
-                        {post.authors?.[0]?.name}
-                      </p>
-                      <p className="text-[13px] lg:text-sm text-[#0A0A0A]/60">
-                        {post.published_at
-                          ? new Date(post.published_at).toLocaleDateString()
-                          : ""}
-                      </p>
-                    </div>
-                  </Link>
+                  <PostCard key={post.id} post={post} />
                 ))}
               </div>
             </div>
@@ -179,8 +72,7 @@ export const Blog = async ({ variant = "all" }) => {
       <div className="container-payai flex justify-center mt-8 lg:mt-16">
         <Link
           className="inline-flex items-center justify-center bg-[linear-gradient(90deg,#4D63F6_17%,#1D45D8_65%)] text-white px-4 py-2.5 text-sm font-medium shadow-[inset_0_0_0_1px_rgba(255,255,255,0.2)] rounded-lg transition-colors hover:bg-[#FFFFFF]"
-          href={isCaseStudies ? `${blogBase}/tag/case-studies` : blogBase || "#"}
-          target="_blank"
+          href={isCaseStudies ? tagUrl("case-studies") : "/blog"}
         >
           {isCaseStudies ? "View All Case Studies" : "View All Posts"}
           <ArrowRight className="w-5 h-5 ml-2" />

--- a/src/lib/agent/llms.ts
+++ b/src/lib/agent/llms.ts
@@ -73,14 +73,14 @@ ${WHEN_TO_USE}
 - [Contact](${SITE_URL}/contact): support, sales, security, and legal contacts.
 - [Developer portal](${SITE_URL}/developers): how to call the PayAI API.
 - [Ecosystem](${SITE_URL}/ecosystem): projects building on PayAI and x402.
-- [Blog](${BLOG_URL}): product and ecosystem updates.
+- [Blog](${BLOG_URL}): product and ecosystem updates. Every post is listed at ${BLOG_URL}.md and syndicated at ${BLOG_URL}/rss.xml.
 - [Privacy policy](${SITE_URL}/privacy-policy)
 - [Terms of service](${SITE_URL}/terms-of-service)
 
 ## Machine-readable surfaces
 
 - [llms-full.txt](${SITE_URL}/llms-full.txt): this guide plus the full text of every page on this site.
-- [Sitemap index](${SITE_URL}/sitemap_index.xml): covers payai.network, blog, and docs.
+- [Sitemap index](${SITE_URL}/sitemap_index.xml): covers payai.network and docs.
 - [MCP manifest](${SITE_URL}/.well-known/mcp.json)
 - [AI catalog](${SITE_URL}/.well-known/ai-catalog.json)
 - [API catalog (RFC 9727)](${SITE_URL}/.well-known/api-catalog)

--- a/src/lib/agent/pages.ts
+++ b/src/lib/agent/pages.ts
@@ -29,7 +29,7 @@ import {
 } from "@/lib/site";
 import { FAQ_DATA } from "@/data/faq";
 import projects from "@/data/projects.json";
-import sitemap from "@/app/sitemap";
+import { staticSitemapEntries } from "@/app/sitemap";
 import { buildOpenApiDocument } from "@/lib/agent/openapi";
 
 type ProjectEntry = {
@@ -345,15 +345,28 @@ export const AUTHORED_PAGES: Record<string, () => string> = {
  * allowlist matters: deriving Markdown from whatever a self-fetch happens to
  * return means an interstitial or an error page can be served as if it were
  * site content.
+ *
+ * Blog posts are deliberately absent: they come from Ghost, so enumerating
+ * them would make this async, and middleware — which reads this set — cannot
+ * await. `isMarkdownPath` matches them by prefix instead.
  */
 export const DERIVED_PAGES: Set<string> = new Set(
-  sitemap()
+  staticSitemapEntries()
     .map((entry) => new URL(entry.url).pathname.replace(/\/+$/, "") || "/")
     .filter((pathname) => !(pathname in AUTHORED_PAGES)),
 );
 
+/** True for the blog index and any post or tag archive beneath it. */
+export function isBlogPath(pathname: string): boolean {
+  return pathname === "/blog" || pathname.startsWith("/blog/");
+}
+
 export function isMarkdownPath(pathname: string): boolean {
-  return pathname in AUTHORED_PAGES || DERIVED_PAGES.has(pathname);
+  return (
+    pathname in AUTHORED_PAGES ||
+    DERIVED_PAGES.has(pathname) ||
+    isBlogPath(pathname)
+  );
 }
 
 export function allMarkdownPaths(): string[] {
@@ -371,7 +384,7 @@ No page exists at \`${pathname}\` on ${SITE_URL}.
 - [Home](${SITE_URL}/) — what PayAI is and how to integrate
 - [Agent guide (llms.txt)](${SITE_URL}/llms.txt) — start here if you are an agent
 - [Full site text (llms-full.txt)](${SITE_URL}/llms-full.txt)
-- [Sitemap index](${SITE_URL}/sitemap_index.xml) — every indexable URL across payai.network, blog, and docs
+- [Sitemap index](${SITE_URL}/sitemap_index.xml) — every indexable URL across payai.network and docs
 - [OpenAPI description](${SITE_URL}/openapi.json) — the callable facilitator API
 - [Documentation](${DOCS_URL}) — quickstarts and protocol reference
 - [Contact](${SITE_URL}/contact)

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,486 @@
+/**
+ * Data layer for the blog, backed by the Ghost Content API.
+ *
+ * Ghost stays the authoring CMS; this site renders the posts. Everything is
+ * fetched through the native `fetch` so Next can dedupe within a render pass
+ * and revalidate on its own schedule — the `@tryghost/content-api` SDK uses
+ * axios internally and is invisible to both.
+ *
+ * The Content API key is a read-only public credential. Ghost designs it to be
+ * shipped to browsers, which is why it lives in a NEXT_PUBLIC_ variable.
+ */
+
+import { htmlToMarkdown } from "@/lib/agent/htmlToMarkdown";
+
+const GHOST_URL = (
+  process.env.NEXT_PUBLIC_GHOST_URL || "https://payai.ghost.io"
+).replace(/\/+$/, "");
+
+const GHOST_KEY = process.env.NEXT_PUBLIC_GHOST_CONTENT_KEY ?? "";
+
+/** Public path prefix. The blog lives in a subdirectory, not on a subdomain. */
+export const BLOG_BASE = "/blog";
+
+/** Posts are re-read hourly, matching the other CMS-backed pages on the site. */
+export const BLOG_REVALIDATE = 3600;
+
+/** The host Ghost still writes into absolute links inside post bodies. */
+const LEGACY_BLOG_HOST = "blog.payai.network";
+
+export type GhostAuthor = {
+  id: string;
+  name: string;
+  slug: string;
+  profile_image: string | null;
+  bio: string | null;
+  website: string | null;
+  twitter: string | null;
+};
+
+export type GhostTag = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  visibility: string;
+};
+
+export type GhostPost = {
+  id: string;
+  uuid: string;
+  title: string;
+  slug: string;
+  html: string | null;
+  excerpt: string | null;
+  custom_excerpt: string | null;
+  feature_image: string | null;
+  feature_image_alt: string | null;
+  feature_image_caption: string | null;
+  published_at: string | null;
+  updated_at: string | null;
+  reading_time: number | null;
+  featured: boolean;
+  meta_title: string | null;
+  meta_description: string | null;
+  og_title: string | null;
+  og_description: string | null;
+  og_image: string | null;
+  twitter_title: string | null;
+  twitter_description: string | null;
+  twitter_image: string | null;
+  canonical_url: string | null;
+  codeinjection_head: string | null;
+  authors?: GhostAuthor[];
+  primary_author?: GhostAuthor | null;
+  tags?: GhostTag[];
+  primary_tag?: GhostTag | null;
+};
+
+/**
+ * Thrown when Ghost is unreachable or errors, as opposed to answering "no such
+ * post". The distinction matters: a transport failure must never be rendered
+ * as a 404, or an outage would deindex live posts.
+ */
+export class GhostUnavailableError extends Error {}
+
+async function contentApi<T>(
+  resource: string,
+  params: Record<string, string>,
+): Promise<T> {
+  if (!GHOST_KEY) {
+    throw new GhostUnavailableError(
+      "NEXT_PUBLIC_GHOST_CONTENT_KEY is not set — cannot read the blog.",
+    );
+  }
+
+  const search = new URLSearchParams({ key: GHOST_KEY, ...params });
+  const url = `${GHOST_URL}/ghost/api/content/${resource}/?${search}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { next: { revalidate: BLOG_REVALIDATE } });
+  } catch (cause) {
+    throw new GhostUnavailableError(`Ghost request failed: ${resource}`, { cause });
+  }
+
+  if (!response.ok) {
+    throw new GhostUnavailableError(
+      `Ghost responded ${response.status} for ${resource}`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+const POST_INCLUDES = { include: "authors,tags", formats: "html" };
+
+/**
+ * Everything a teaser needs and nothing more.
+ *
+ * Listing views render a title, excerpt, image, and byline, but a default
+ * Ghost query also returns each post's full rendered body. Those bodies are
+ * ~9KB apiece and get serialized into the RSC payload of every page that shows
+ * a card, so the homepage was shipping four complete articles to render four
+ * summaries. Only the post page asks for `html`.
+ */
+const CARD_FIELDS = [
+  "id",
+  "uuid",
+  "title",
+  "slug",
+  "excerpt",
+  "custom_excerpt",
+  "feature_image",
+  "feature_image_alt",
+  "published_at",
+  "updated_at",
+  "reading_time",
+  "featured",
+].join(",");
+
+const CARD_QUERY = { include: "authors,tags", fields: CARD_FIELDS };
+
+export async function getPosts(limit: number | "all" = "all"): Promise<GhostPost[]> {
+  const data = await contentApi<{ posts: GhostPost[] }>("posts", {
+    ...CARD_QUERY,
+    limit: String(limit),
+    order: "published_at desc",
+  });
+  return data.posts ?? [];
+}
+
+/** Posts with their rendered bodies. Only the feed needs this. */
+export async function getPostsWithContent(): Promise<GhostPost[]> {
+  const data = await contentApi<{ posts: GhostPost[] }>("posts", {
+    ...POST_INCLUDES,
+    limit: "all",
+    order: "published_at desc",
+  });
+  return data.posts ?? [];
+}
+
+/** Returns null when Ghost is reachable and has no post with this slug. */
+export async function getPost(slug: string): Promise<GhostPost | null> {
+  const data = await contentApi<{ posts: GhostPost[] }>("posts", {
+    ...POST_INCLUDES,
+    limit: "1",
+    filter: `slug:${slug}`,
+  });
+  return data.posts?.[0] ?? null;
+}
+
+export async function getPostSlugs(): Promise<string[]> {
+  const data = await contentApi<{ posts: Array<{ slug: string }> }>("posts", {
+    limit: "all",
+    fields: "slug",
+  });
+  return (data.posts ?? []).map((post) => post.slug);
+}
+
+export async function getPostsByTag(tagSlug: string): Promise<GhostPost[]> {
+  const data = await contentApi<{ posts: GhostPost[] }>("posts", {
+    ...CARD_QUERY,
+    limit: "all",
+    filter: `tag:${tagSlug}`,
+    order: "published_at desc",
+  });
+  return data.posts ?? [];
+}
+
+export async function getTag(tagSlug: string): Promise<GhostTag | null> {
+  const data = await contentApi<{ tags: GhostTag[] }>("tags", {
+    limit: "1",
+    filter: `slug:${tagSlug}`,
+  });
+  return data.tags?.[0] ?? null;
+}
+
+/**
+ * Public tags that actually carry posts. `include=count.posts` is what makes
+ * the count available; without it every tag looks equally substantial.
+ */
+export async function getTagsWithCounts(): Promise<
+  Array<GhostTag & { count: { posts: number } }>
+> {
+  const data = await contentApi<{
+    tags: Array<GhostTag & { count?: { posts: number } }>;
+  }>("tags", {
+    limit: "all",
+    include: "count.posts",
+    filter: "visibility:public",
+  });
+
+  return (data.tags ?? [])
+    .map((tag) => ({ ...tag, count: { posts: tag.count?.posts ?? 0 } }))
+    .filter((tag) => tag.count.posts > 0);
+}
+
+/**
+ * Posts sharing the current post's primary tag, most recent first. Falls back
+ * to the newest posts so the slot is never empty on a single-tag post.
+ */
+export async function getRelatedPosts(
+  post: GhostPost,
+  limit = 3,
+): Promise<GhostPost[]> {
+  const exclude = (candidates: GhostPost[]) =>
+    candidates.filter((candidate) => candidate.id !== post.id).slice(0, limit);
+
+  if (post.primary_tag) {
+    const sameTag = exclude(await getPostsByTag(post.primary_tag.slug));
+    if (sameTag.length >= limit) return sameTag;
+
+    const recent = exclude(await getPosts(limit + 4));
+    const seen = new Set(sameTag.map((candidate) => candidate.id));
+    return [...sameTag, ...recent.filter((c) => !seen.has(c.id))].slice(0, limit);
+  }
+
+  return exclude(await getPosts(limit + 1));
+}
+
+/**
+ * Rewrites the absolute subdomain links Ghost stores in post bodies into paths
+ * on this site.
+ *
+ * Posts cross-link each other heavily — 58 such links across 21 posts — and
+ * every one of them would otherwise take a redirect hop back out to the old
+ * host and in again. Rewriting them keeps the link internal and direct.
+ *
+ * Ghost-hosted assets under /content/ are deliberately left alone: they are
+ * served from storage.ghost.io and are not ours to reroute.
+ */
+export function rewriteGhostHtml(html: string | null): string {
+  if (!html) return "";
+
+  /*
+   * Ghost's outbound link tagging stamps ?ref=<site host> onto external links,
+   * derived from the configured site URL at render time. That value is about to
+   * become payai.ghost.io when the custom domain is released, which would be
+   * wrong in a new way — these clicks come from payai.network/blog. Normalising
+   * it here keeps the attribution accurate and stable no matter what Ghost's
+   * own site URL is set to.
+   */
+  const withNormalisedRefs = html.replace(
+    new RegExp(`([?&]ref=)(${LEGACY_BLOG_HOST}|payai\\.ghost\\.io)\\b`, "g"),
+    (_match, prefix: string) => `${prefix}payai.network`,
+  );
+
+  return withNormalisedRefs.replace(
+    new RegExp(`https?://${LEGACY_BLOG_HOST.replace(/\./g, "\\.")}(/[^"'\\s)]*)?`, "g"),
+    (match, path: string | undefined) => {
+      const pathname = path ?? "/";
+      if (pathname.startsWith("/content/")) return match;
+      const trimmed = pathname.replace(/\/+$/, "");
+      return trimmed === "" ? BLOG_BASE : `${BLOG_BASE}${trimmed}`;
+    },
+  );
+}
+
+/**
+ * JSON-LD blocks authored in a post's Ghost code injection, minus the types
+ * this site already generates.
+ *
+ * One post carries a hand-written FAQPage worth keeping; another carries an
+ * Article block that predates this migration, still points at the old host,
+ * and is strictly worse than the BlogPosting built from Ghost's own fields.
+ * Filtering by type keeps the first and drops the second without per-post
+ * special cases. Only JSON-LD is carried over — never arbitrary markup.
+ */
+const GENERATED_SCHEMA_TYPES = new Set([
+  "Article",
+  "BlogPosting",
+  "NewsArticle",
+  "Organization",
+  "WebSite",
+  "WebPage",
+  "BreadcrumbList",
+]);
+
+export function extractInjectedJsonLd(post: GhostPost): unknown[] {
+  const head = post.codeinjection_head;
+  if (!head) return [];
+
+  const blocks = [
+    ...head.matchAll(
+      /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+    ),
+  ];
+
+  const kept: unknown[] = [];
+  for (const [, body] of blocks) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rewriteGhostHtml(body.trim()));
+    } catch {
+      // A malformed block is dropped rather than emitted as broken markup.
+      continue;
+    }
+
+    for (const node of Array.isArray(parsed) ? parsed : [parsed]) {
+      const type = (node as { "@type"?: unknown })?.["@type"];
+      if (typeof type === "string" && GENERATED_SCHEMA_TYPES.has(type)) continue;
+      kept.push(node);
+    }
+  }
+
+  return kept;
+}
+
+/** Canonical public URL for a post on this site. */
+export function postUrl(slug: string): string {
+  return `${BLOG_BASE}/${slug}`;
+}
+
+export function tagUrl(slug: string): string {
+  return `${BLOG_BASE}/tag/${slug}`;
+}
+
+/** Cuts at a word boundary so a summary never ends mid-word. */
+function truncateAtWord(value: string, limit: number): string {
+  const text = value.trim().replace(/\s+/g, " ");
+  if (text.length <= limit) return text;
+  const cut = text.slice(0, limit);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${(lastSpace > limit * 0.6 ? cut.slice(0, lastSpace) : cut).replace(/[.,;:—-]$/, "")}…`;
+}
+
+/**
+ * The summary an author actually wrote, or nothing.
+ *
+ * Ghost synthesises `excerpt` by hard-cutting the first 500 characters of the
+ * body, which ends mid-word. That is fine as a fallback teaser but wrong as a
+ * standfirst under a headline, so this returns only the deliberate version.
+ */
+export function postExcerpt(post: GhostPost): string {
+  return (post.custom_excerpt || "").trim();
+}
+
+/** Card and feed summary: the authored excerpt, else a tidy cut of the body. */
+export function postTeaser(post: GhostPost): string {
+  const authored = postExcerpt(post);
+  if (authored) return authored;
+  return post.excerpt ? truncateAtWord(post.excerpt, 200) : "";
+}
+
+/** Meta description: search snippets are cut around 155 characters. */
+export function postMetaDescription(post: GhostPost): string {
+  const authored = (post.meta_description || post.custom_excerpt || "").trim();
+  if (authored) return truncateAtWord(authored, 155);
+  return post.excerpt ? truncateAtWord(post.excerpt, 155) : "";
+}
+
+export function formatPostDate(value: string | null): string {
+  if (!value) return "";
+  return new Date(value).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * Minimum posts for a tag archive to be indexable.
+ *
+ * Ghost has 18 public tags across 21 posts, so most archives would be one or
+ * two entries deep. Thin archives are the classic way a migration like this
+ * dilutes a site instead of strengthening it, so they render for humans and
+ * carry noindex. The sitemap uses the same threshold.
+ */
+export const TAG_INDEX_MIN_POSTS = 3;
+
+/**
+ * Prepares a post body for rendering: internal links rewritten, and tables
+ * wrapped so they can scroll inside their own box.
+ *
+ * Ghost emits bare <table> elements and these posts lean on them heavily —
+ * 157 cells across 21 posts — which is enough to push the whole page into
+ * horizontal scroll on a phone. The wrapper is styled by `.blog-prose
+ * .table-wrapper` in globals.css.
+ *
+ * Kept separate from `rewriteGhostHtml` because that function also runs over
+ * JSON-LD and feed content, where wrapping markup would make no sense.
+ */
+export function renderPostHtml(html: string | null): string {
+  return rewriteGhostHtml(html).replace(
+    /<table[\s>][\s\S]*?<\/table>/g,
+    (table) => `<div class="table-wrapper">${table}</div>`,
+  );
+}
+
+/**
+ * Markdown representation of a blog path, for `Accept: text/markdown` and the
+ * `.md` suffix.
+ *
+ * Built from Ghost's own HTML rather than by re-fetching the rendered page:
+ * the post body is already the exact content an agent wants, without the
+ * navbar, related-posts strip, and newsletter embed a self-fetch would drag
+ * in. Returns null when the path does not resolve, so the caller can answer a
+ * real 404 instead of a page-shaped placeholder.
+ */
+export async function blogMarkdown(
+  pathname: string,
+  siteUrl: string,
+): Promise<string | null> {
+  const listing = (heading: string, intro: string, posts: GhostPost[]) =>
+    [
+      `# ${heading}`,
+      "",
+      intro,
+      "",
+      ...posts.map((post) => {
+        const excerpt = postTeaser(post);
+        return `- [${post.title}](${siteUrl}${postUrl(post.slug)})${
+          excerpt ? ` — ${excerpt}` : ""
+        }`;
+      }),
+    ].join("\n");
+
+  if (pathname === "/blog") {
+    const posts = await getPosts();
+    return listing(
+      "PayAI Blog",
+      "Insights and updates from the x402 ecosystem and PayAI Network.",
+      posts,
+    );
+  }
+
+  const tagMatch = pathname.match(/^\/blog\/tag\/([^/]+)$/);
+  if (tagMatch) {
+    const [, tagSlug] = tagMatch;
+    const [tag, posts] = await Promise.all([
+      getTag(tagSlug),
+      getPostsByTag(tagSlug),
+    ]);
+    if (!tag || posts.length === 0) return null;
+    return listing(
+      `${tag.name} — PayAI Blog`,
+      tag.description || `Posts tagged ${tag.name}.`,
+      posts,
+    );
+  }
+
+  const postMatch = pathname.match(/^\/blog\/([^/]+)$/);
+  if (!postMatch) return null;
+
+  const post = await getPost(postMatch[1]);
+  if (!post) return null;
+
+  const author = post.primary_author ?? post.authors?.[0];
+  const meta = [
+    author?.name ? `Author: ${author.name}` : null,
+    post.published_at ? `Published: ${formatPostDate(post.published_at)}` : null,
+    post.tags?.length
+      ? `Topics: ${post.tags.map((tag) => tag.name).join(", ")}`
+      : null,
+  ].filter(Boolean);
+
+  return [
+    `# ${post.title}`,
+    postExcerpt(post),
+    meta.join(" · "),
+    htmlToMarkdown(rewriteGhostHtml(post.html)),
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -66,7 +66,6 @@ export function buildOrganizationSchema() {
       "https://github.com/PayAINetwork",
       "https://t.me/PayAINetwork",
       "https://discord.gg/eWJRwMpebQ",
-      "https://blog.payai.network",
     ],
   };
 }
@@ -163,5 +162,129 @@ export function buildFaqSchema(items) {
         text: answer,
       },
     })),
+  };
+}
+
+/**
+ * Blog schema for the blog index — names the collection so assistants can tell
+ * the archive apart from an individual post.
+ */
+export function buildBlogSchema(posts) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "@id": `${SITE_URL}/blog`,
+    name: "PayAI Blog",
+    url: `${SITE_URL}/blog`,
+    description:
+      "Insights and updates from the x402 ecosystem and PayAI Network — agentic payments, facilitator engineering, and the machine economy.",
+    publisher: {
+      "@type": "Organization",
+      name: "PayAI",
+      logo: { "@type": "ImageObject", url: LOGO_URL },
+    },
+    blogPost: posts.map((post) => ({
+      "@type": "BlogPosting",
+      headline: post.title,
+      url: `${SITE_URL}/blog/${post.slug}`,
+      datePublished: post.published_at,
+    })),
+  };
+}
+
+/**
+ * BlogPosting schema for a single post.
+ *
+ * Built from Ghost's own fields rather than hand-authored in the post's code
+ * injection, so dates and authorship cannot drift from what is published.
+ * `dateModified` matters here: it is how a crawler knows an updated post is
+ * worth recrawling.
+ */
+export function buildBlogPostingSchema(post) {
+  const url = `${SITE_URL}/blog/${post.slug}`;
+  const authors = post.authors?.length
+    ? post.authors
+    : [post.primary_author].filter(Boolean);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "@id": url,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    headline: post.title,
+    url,
+    /*
+     * Authored summaries only. Ghost's synthesised `excerpt` is a hard 500-character
+     * cut of the body that ends mid-word, which is not something to publish as a
+     * description in structured data.
+     */
+    ...(post.meta_description || post.custom_excerpt
+      ? { description: post.meta_description || post.custom_excerpt }
+      : {}),
+    ...(post.feature_image ? { image: [post.feature_image] } : {}),
+    datePublished: post.published_at,
+    dateModified: post.updated_at || post.published_at,
+    author: authors.length
+      ? authors.map((author) => ({
+          "@type": "Person",
+          name: author.name,
+          ...(author.website ? { url: author.website } : {}),
+        }))
+      : [{ "@type": "Organization", name: "PayAI", url: SITE_URL }],
+    publisher: {
+      "@type": "Organization",
+      name: "PayAI",
+      url: SITE_URL,
+      logo: { "@type": "ImageObject", url: LOGO_URL },
+    },
+    ...(post.tags?.length
+      ? { keywords: post.tags.map((tag) => tag.name).join(", ") }
+      : {}),
+    ...(post.reading_time
+      ? { timeRequired: `PT${post.reading_time}M` }
+      : {}),
+    isPartOf: { "@type": "Blog", "@id": `${SITE_URL}/blog` },
+  };
+}
+
+/**
+ * BreadcrumbList — tells search engines where a post sits in the hierarchy,
+ * which is the point of moving the blog into a subdirectory in the first place.
+ *
+ * @param {Array<{ name: string, path: string }>} trail
+ */
+export function buildBreadcrumbSchema(trail) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: trail.map(({ name, path }, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name,
+      item: `${SITE_URL}${path}`,
+    })),
+  };
+}
+
+/**
+ * CollectionPage schema for a tag archive.
+ */
+export function buildTagPageSchema(tag, posts) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${tag.name} — PayAI Blog`,
+    url: `${SITE_URL}/blog/tag/${tag.slug}`,
+    ...(tag.description ? { description: tag.description } : {}),
+    isPartOf: { "@type": "Blog", "@id": `${SITE_URL}/blog` },
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: posts.map((post, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `${SITE_URL}/blog/${post.slug}`,
+        name: post.title,
+      })),
+    },
   };
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -26,10 +26,13 @@ export const DOCS_URL = env(
   process.env.NEXT_PUBLIC_DOCS_PAYAI_NETWORK,
   "https://docs.payai.network",
 );
-export const BLOG_URL = env(
-  process.env.NEXT_PUBLIC_BLOG_PAYAI_NETWORK,
-  "https://blog.payai.network",
-);
+/**
+ * The blog is a subdirectory of this site, not a subdomain. Deliberately not
+ * read from NEXT_PUBLIC_BLOG_PAYAI_NETWORK: that variable still points at the
+ * old host in the deployed environments, and it must not be able to send
+ * agents or crawlers back to a URL that now only answers with a redirect.
+ */
+export const BLOG_URL = `${SITE_URL}/blog`;
 export const MERCHANT_PORTAL_URL = "https://merchant.payai.network";
 export const ECHO_MERCHANT_URL = env(
   process.env.NEXT_PUBLIC_ECHO_MERCHANT_URL,


### PR DESCRIPTION
## Why

`payai.network` publishes **7 indexable URLs**. `blog.payai.network` publishes **21 posts** plus tag archives. Every page targeting the keywords we need to own — "x402 payment protocol", "agentic payments", "micropayments" — and every page that earns an inbound link sits on a host that is not the one that converts.

Subdomains are not penalised, and Google's line is that either layout works. But that is about capability, not outcome: link equity and host-level quality signals do not fully merge across a host boundary. `sitemap_index.xml` on `main` already names the problem in its own header comment — *"the SEO equity fragmentation that comes with hosting on separate subdomains."*

This closes it. **Indexable URLs on the money domain go from 7 to 36.**

Doing it now rather than later also matters: the same argument applies at 200 posts, but the migration costs more.

## Why native rendering rather than proxying Ghost

Ghost(Pro) gates subdirectory/reverse-proxy setups behind the Business plan ($199/mo yearly) plus a $50/mo add-on. We are on Publisher ($29/mo), so proxying would cost **~+$220/mo (~$2,700/yr)**. The Content API is on every plan, `@tryghost/content-api` was already a dependency, and `src/lib/ghost.ts` already existed.

Ghost stays the authoring CMS. Nothing about the writing workflow changes.

## What's here

**Rendering** — `/blog`, `/blog/[slug]`, `/blog/tag/[slug]`, `/blog/rss.xml`, all ISR at 1h. Prose styles cover the Koenig cards these posts actually use (image, callout, CTA) rather than pulling Ghost's stylesheet onto our most-linked pages.

**SEO** — sitemap 7 → 36 URLs with Ghost's real `updated_at` as `lastModified`; BlogPosting + BreadcrumbList generated from Ghost's fields; tag archives below 3 posts render but stay `noindex` so this doesn't dilute the site it's meant to strengthen.

**Agent surfaces** — posts serve Markdown from the CMS payload (not by re-reading their own HTML), so an agent gets the article without the navbar and newsletter embed. Unknown slugs 404 properly instead of returning a page-shaped placeholder.

**Newsletter** — Ghost's official cross-domain embed against `payai.ghost.io`. Members list untouched; comments and paid tiers aren't in use.

## Things worth a reviewer's attention

- **58 cross-post links** were absolute `blog.payai.network` URLs. They're rewritten to relative paths so they stay internal rather than taking a redirect hop out of the domain and back.
- **Ghost's `?ref=` outbound tagging** is normalised to `payai.network` (261 links). Ghost derives that value from its site URL, so after the domain is released it would start emitting `?ref=payai.ghost.io` — wrong in a new way. **If any dashboard segments on `ref=blog.payai.network`, that series ends here.** One-line revert in `rewriteGhostHtml` if you'd rather keep continuity.
- **`sitemap()` is now async**, which `DERIVED_PAGES` can't consume — it feeds middleware, which can't await. Static entries are split into a sync export; blog paths match by prefix.
- **JSON-LD from code injection** is carried over only for types we don't generate. That keeps one post's hand-written FAQPage and drops another's stale `Article` block that predates this migration and still pointed at the old host.
- **Listing views no longer request post bodies.** They were pulling each post's full `html` from Ghost to render four summaries. ~~Homepage is 62KB lighter.~~ **Correction:** that 62KB was measured dev-server vs dev-server. `Blog.jsx` and `PostCard` are Server Components, so post objects never cross to the client and never reach the production RSC payload — the live homepage carries no post bodies today. The change reduces the Ghost API response and what Next caches, **not** bytes shipped to browsers. No production page-weight win; the original claim was wrong.

## Pre-existing issue found, not fixed here

The Relume Tailwind preset **replaces** `theme.maxWidth` with `{xxs…xxl, full}`, so **`max-w-3xl` compiles to nothing site-wide**. `/about` and `src/components/content/Markdown.jsx` both use it and render full-bleed body text as a result. Blog code uses explicit values (`max-w-[48rem]`) to sidestep it. Worth a separate fix.

## Verification

Clean `pnpm build` (66/66 pages, 21 posts + 18 tags prerendered) and lint. 16/16 checks pass: route status codes, single self-referential canonicals, thin-tag noindex, Markdown negotiation with real 404s, and zero references to the old host in rendered output or the feed. Walked desktop and mobile — wide tables scroll in their own box, the page never scrolls horizontally, no console errors.

## Not in this PR

**The cutover is deliberately separate.** This ships `/blog` alongside the live subdomain so it can be reviewed against production before anything is redirected. DNS, the Ghost domain release, and the 301s are in `workspace/payai/blog-subdirectory-cutover-runbook.md`, including rollback.

Merging this changes nothing for existing blog URLs.

