### PR TITLE
fix: stop the partners diagram spilling over the logo strip

### DIFF
--- a/src/components/sections/Partners.jsx
+++ b/src/components/sections/Partners.jsx
@@ -15,7 +15,13 @@ const PARTNERS_DATA = [
 export const Partners = () => {
   return (
     <section className="bg-white">
-      <div className="container-payai p-8 lg:pt-20 lg:pb-8 flex flex-col items-center lg:h-screen">
+      {/*
+        min-h-screen, not h-screen: the section still fills the viewport on
+        large screens, but a hard 100vh clipped its own content once the
+        supported-networks copy was added, spilling the diagram over the
+        partner logo strip below.
+      */}
+      <div className="container-payai p-8 lg:pt-20 lg:pb-8 flex flex-col items-center lg:min-h-screen">
         <div className="lg:w-[720px] flex flex-col items-center">
           <h2 className="text-2xl lg:text-[36px] text-[#09090B]">
             Ecosystem & Partners


### PR DESCRIPTION
Regression from #79 — my fault, and visible on production now.

The `Ecosystem & Partners` container was `lg:h-screen`, a hard 100vh. The supported-networks copy I added in #79 pushed its content to **943px inside a 720px box**, so the diagram overflowed by exactly **223px** and rendered on top of the partner logo strip beneath it.

`min-h-screen` keeps the full-viewport look on large screens but lets the section grow with its content.

**Verified at three widths** — container overflow `0` at 1440, 1024 and 375; the diagram sits 32px *inside* its container; a geometric sweep finds **zero** elements overlapping it; no horizontal page overflow on mobile.

Worth noting the same pattern exists elsewhere in the codebase — any fixed-height section will clip the moment its copy grows. Not changing those here, but they're the same latent bug.